### PR TITLE
Fix issues that was detected when trying to deploy to CentOS 8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,7 @@ boundary_checksum_file_url: "{{ boundary_url }}/{{ boundary_version }}/{{ bounda
 # Database
 boundary_psql_username: boundary
 boundary_psql_dbname: boundary
+boundary_psql_extra_options: ""
 
 # KMS Configuration - default to Hashicorp dev build keys
 #  only suitable for learning, as documented at https://www.boundaryproject.io/docs/configuration/kms/aead

--- a/docs/kms_transit.md
+++ b/docs/kms_transit.md
@@ -19,7 +19,7 @@ Add the Vault transit keystore details
 ```YAML
 # Required settings
 boundary_kms_type: 'transit'
-vault_instances:
+boundary_vault_instances:
   - vault.example.com
 boundary_transit_mount_path: 'transit/'
 boundary_transit_namespace: 'ns1'

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -26,7 +26,11 @@
       shell: "{{ boundary_command }} database init -config {{ boundary_controller_file }} {{ boundary_db_init_flags }}"
       run_once: True
       register: boundary_database_init
-      changed_when: boundary_database_init.stdout != 'Database already initialized.'
+      changed_when:
+        - "'Database has already been initialized.' not in boundary_database_init.stderr"
+      failed_when:
+        - "boundary_database_init.rc != 0"
+        - "'Database has already been initialized.' not in boundary_database_init.stderr"
       when: not lookup('env', 'MOLECULE_FILE')  # skip when testing for now
 
     - name: starting and enabling boundary-controller

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,9 @@
   include_tasks: tls_api.yml
 
 - name: install Vault Transit TLS certificates
-  when: boundary_kms_type == 'transit'
+  when:
+    - boundary_kms_type == 'transit'
+    - (true if boundary_vault_no_tls else false)
   include_tasks: tls_vault_transit.yml
 
 - name: configure boundary

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     boundary_iface: "{{ ansible_default_ipv4.interface }}"
 
 - name: set boundary_address
+  when: boundary_address is undefined
   set_fact:
     boundary_address: "{{ hostvars[inventory_hostname]['ansible_'+boundary_iface]['ipv4']['address'] }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
 - name: install Vault Transit TLS certificates
   when:
     - boundary_kms_type == 'transit'
-    - (true if boundary_vault_no_tls else false)
+    - (true if boundary_vault_use_tls else false)
   include_tasks: tls_vault_transit.yml
 
 - name: configure boundary

--- a/templates/boundary-controller.hcl.j2
+++ b/templates/boundary-controller.hcl.j2
@@ -7,7 +7,7 @@ controller {
   public_cluster_addr = "{{ inventory_hostname }}"
 
   database {
-      url = "postgresql://{{ boundary_psql_username }}:{{ boundary_psql_password }}@{{ boundary_psql_endpoint }}/{{ boundary_psql_dbname }}"
+      url = "postgresql://{{ boundary_psql_username }}:{{ boundary_psql_password }}@{{ boundary_psql_endpoint }}/{{ boundary_psql_dbname }}{{ boundary_psql_extra_options }}"
   }
 }
 

--- a/templates/boundary-controller.hcl.j2
+++ b/templates/boundary-controller.hcl.j2
@@ -86,7 +86,7 @@ kms "gcpckms" {
 {% elif boundary_kms_type == 'transit' %}
 kms "transit" {
   purpose            = "{{ key_type }}"
-  address            = "https://{{ vault_instances[0] }}:8200"
+  address            = "https://{{ boundary_vault_instances[0] }}:8200"
   token              = "{{ lookup('env','VAULT_TOKEN') }}"
   disable_renewal    = "{{ boundary_transit_disable_renewal |default('false') }}"
 
@@ -96,7 +96,7 @@ kms "transit" {
   mount_path         = "{{ boundary_transit_mount_path }}"
 
   // TLS Configuration
-  tls_server_name    = "{{ boundary_transit_tls_server_name |default(vault_instances[0]) }}"
+  tls_server_name    = "{{ boundary_transit_tls_server_name |default(boundary_vault_instances[0]) }}"
   tls_ca_cert        = "{{ boundary_transit_tls_ca_file     |default('') }}"
   tls_client_cert    = "{{ boundary_transit_tls_cert_file   |default('') }}"
   tls_client_key     = "{{ boundary_transit_tls_key_file    |default('') }}"

--- a/templates/boundary-controller.hcl.j2
+++ b/templates/boundary-controller.hcl.j2
@@ -96,11 +96,13 @@ kms "transit" {
   mount_path         = "{{ boundary_transit_mount_path }}"
 
   // TLS Configuration
+{% if boundary_vault_use_tls %}
   tls_server_name    = "{{ boundary_transit_tls_server_name |default(boundary_vault_instances[0]) }}"
   tls_ca_cert        = "{{ boundary_transit_tls_ca_file     |default('') }}"
   tls_client_cert    = "{{ boundary_transit_tls_cert_file   |default('') }}"
   tls_client_key     = "{{ boundary_transit_tls_key_file    |default('') }}"
   tls_skip_verify    = "{{ boundary_transit_tls_skip_verify |default('false') }}"
+{% endif %}
 }
 {% endif %}
 {% endfor %}

--- a/templates/boundary-controller.hcl.j2
+++ b/templates/boundary-controller.hcl.j2
@@ -86,7 +86,7 @@ kms "gcpckms" {
 {% elif boundary_kms_type == 'transit' %}
 kms "transit" {
   purpose            = "{{ key_type }}"
-  address            = "https://{{ boundary_vault_instances[0] }}:8200"
+  address            = "{{ 'https' if boundary_vault_use_tls else 'http' }}://{{ boundary_vault_instances[0] }}:8200"
   token              = "{{ lookup('env','VAULT_TOKEN') }}"
   disable_renewal    = "{{ boundary_transit_disable_renewal |default('false') }}"
 
@@ -95,8 +95,8 @@ kms "transit" {
   namespace          = "{{ boundary_transit_namespace }}"
   mount_path         = "{{ boundary_transit_mount_path }}"
 
-  // TLS Configuration
 {% if boundary_vault_use_tls %}
+  // TLS Configuration
   tls_server_name    = "{{ boundary_transit_tls_server_name |default(boundary_vault_instances[0]) }}"
   tls_ca_cert        = "{{ boundary_transit_tls_ca_file     |default('') }}"
   tls_client_cert    = "{{ boundary_transit_tls_cert_file   |default('') }}"

--- a/templates/boundary-controller.hcl.j2
+++ b/templates/boundary-controller.hcl.j2
@@ -3,9 +3,9 @@ disable_mlock = {{ boundary_disable_mlock | lower }}
 controller {
   name = "{{ ansible_hostname }}-controller"
   description = "Boundary controller."
-  
+
   public_cluster_addr = "{{ inventory_hostname }}"
-  
+
   database {
       url = "postgresql://{{ boundary_psql_username }}:{{ boundary_psql_password }}@{{ boundary_psql_endpoint }}/{{ boundary_psql_dbname }}"
   }
@@ -86,7 +86,7 @@ kms "gcpckms" {
 {% elif boundary_kms_type == 'transit' %}
 kms "transit" {
   purpose            = "{{ key_type }}"
-  address            = "https://{{ groups.vault_instances[0] }}:8200"
+  address            = "https://{{ vault_instances[0] }}:8200"
   token              = "{{ lookup('env','VAULT_TOKEN') }}"
   disable_renewal    = "{{ boundary_transit_disable_renewal |default('false') }}"
 
@@ -96,7 +96,7 @@ kms "transit" {
   mount_path         = "{{ boundary_transit_mount_path }}"
 
   // TLS Configuration
-  tls_server_name    = "{{ boundary_transit_tls_server_name |default(groups.vault_instances[0]) }}"
+  tls_server_name    = "{{ boundary_transit_tls_server_name |default(vault_instances[0]) }}"
   tls_ca_cert        = "{{ boundary_transit_tls_ca_file     |default('') }}"
   tls_client_cert    = "{{ boundary_transit_tls_cert_file   |default('') }}"
   tls_client_key     = "{{ boundary_transit_tls_key_file    |default('') }}"

--- a/templates/boundary-worker.hcl.j2
+++ b/templates/boundary-worker.hcl.j2
@@ -53,7 +53,7 @@ kms "gcpckms" {
 {% elif boundary_kms_type == 'transit' %}
 kms "transit" {
   purpose            = "{{ key_type }}"
-  address            = "https://{{ vault_instances[0] }}:8200"
+  address            = "https://{{ boundary_vault_instances[0] }}:8200"
   token              = "{{ lookup('env','VAULT_TOKEN') }}"
   disable_renewal    = "{{ boundary_transit_disable_renewal |default('false') }}"
 
@@ -63,7 +63,7 @@ kms "transit" {
   mount_path         = "{{ boundary_transit_mount_path }}"
 
   // TLS Configuration
-  tls_server_name    = "{{ boundary_transit_tls_server_name |default(vault_instances[0]) }}"
+  tls_server_name    = "{{ boundary_transit_tls_server_name |default(boundary_vault_instances[0]) }}"
   tls_ca_cert        = "{{ boundary_transit_tls_ca_file     |default('') }}"
   tls_client_cert    = "{{ boundary_transit_tls_cert_file   |default('') }}"
   tls_client_key     = "{{ boundary_transit_tls_key_file    |default('') }}"

--- a/templates/boundary-worker.hcl.j2
+++ b/templates/boundary-worker.hcl.j2
@@ -53,7 +53,7 @@ kms "gcpckms" {
 {% elif boundary_kms_type == 'transit' %}
 kms "transit" {
   purpose            = "{{ key_type }}"
-  address            = "https://{{ boundary_vault_instances[0] }}:8200"
+  address            = "{{ 'https' if boundary_vault_use_tls else 'http' }}://{{ boundary_vault_instances[0] }}:8200"
   token              = "{{ lookup('env','VAULT_TOKEN') }}"
   disable_renewal    = "{{ boundary_transit_disable_renewal |default('false') }}"
 
@@ -62,8 +62,8 @@ kms "transit" {
   namespace          = "{{ boundary_transit_namespace }}"
   mount_path         = "{{ boundary_transit_mount_path }}"
 
-  // TLS Configuration
 {% if boundary_vault_use_tls %}
+  // TLS Configuration
   tls_server_name    = "{{ boundary_transit_tls_server_name |default(boundary_vault_instances[0]) }}"
   tls_ca_cert        = "{{ boundary_transit_tls_ca_file     |default('') }}"
   tls_client_cert    = "{{ boundary_transit_tls_cert_file   |default('') }}"

--- a/templates/boundary-worker.hcl.j2
+++ b/templates/boundary-worker.hcl.j2
@@ -63,11 +63,13 @@ kms "transit" {
   mount_path         = "{{ boundary_transit_mount_path }}"
 
   // TLS Configuration
+{% if boundary_vault_use_tls %}
   tls_server_name    = "{{ boundary_transit_tls_server_name |default(boundary_vault_instances[0]) }}"
   tls_ca_cert        = "{{ boundary_transit_tls_ca_file     |default('') }}"
   tls_client_cert    = "{{ boundary_transit_tls_cert_file   |default('') }}"
   tls_client_key     = "{{ boundary_transit_tls_key_file    |default('') }}"
   tls_skip_verify    = "{{ boundary_transit_tls_skip_verify |default('false') }}"
+{% endif %}
 }
 {% endif %}
 {% endfor %}

--- a/templates/boundary-worker.hcl.j2
+++ b/templates/boundary-worker.hcl.j2
@@ -53,7 +53,7 @@ kms "gcpckms" {
 {% elif boundary_kms_type == 'transit' %}
 kms "transit" {
   purpose            = "{{ key_type }}"
-  address            = "https://{{ groups.vault_instances[0] }}:8200"
+  address            = "https://{{ vault_instances[0] }}:8200"
   token              = "{{ lookup('env','VAULT_TOKEN') }}"
   disable_renewal    = "{{ boundary_transit_disable_renewal |default('false') }}"
 
@@ -63,7 +63,7 @@ kms "transit" {
   mount_path         = "{{ boundary_transit_mount_path }}"
 
   // TLS Configuration
-  tls_server_name    = "{{ boundary_transit_tls_server_name |default(groups.vault_instances[0]) }}"
+  tls_server_name    = "{{ boundary_transit_tls_server_name |default(vault_instances[0]) }}"
   tls_ca_cert        = "{{ boundary_transit_tls_ca_file     |default('') }}"
   tls_client_cert    = "{{ boundary_transit_tls_cert_file   |default('') }}"
   tls_client_key     = "{{ boundary_transit_tls_key_file    |default('') }}"


### PR DESCRIPTION
This PR fixes several issues detected while attempting to deploy it to a test server running CentOS 8.

* Mainly it allows you to not use TLS when connecting to a Vault Transit KSM storage.
* It also allows you to set extra connection parameters for the postgres connection, for example to disable ssl connection.
* It fixes incorrect fault handling in the db-init task.
* It removes the requirement on vault_instances variable must be defined in group-vars. Now it can be defined globally as well.
